### PR TITLE
Add support for proxying Fetch API requests to LocalStack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ dist
 .tern-port
 
 .idea/
+
+_metadata/


### PR DESCRIPTION
Add support for proxying [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) requests from the browser directly to LocalStack. 

This now also allows us to use the AWS Console with certain LocalStack services, e.g., CloudFormation.

⚠️ Please note that this is not officially supported - use it at your own discretion and risk! ⚠️ 

https://github.com/user-attachments/assets/9d0d6c11-895d-4394-939d-11900dacff06

/cc @simonrw 